### PR TITLE
feat:adding output_features to the GenerateCSV construct for table generation

### DIFF
--- a/API.md
+++ b/API.md
@@ -7022,6 +7022,7 @@ const textractGenerateCSVProps: TextractGenerateCSVProps = { ... }
 | <code><a href="#amazon-textract-idp-cdk-constructs.TextractGenerateCSVProps.property.lambdaTimeout">lambdaTimeout</a></code> | <code>number</code> | *No description.* |
 | <code><a href="#amazon-textract-idp-cdk-constructs.TextractGenerateCSVProps.property.metaDataToAppend">metaDataToAppend</a></code> | <code>string[]</code> | The generated CSV can have any meta-data from the manifest file included. |
 | <code><a href="#amazon-textract-idp-cdk-constructs.TextractGenerateCSVProps.property.name">name</a></code> | <code>string</code> | The name of the execution, same as that of StartExecution. |
+| <code><a href="#amazon-textract-idp-cdk-constructs.TextractGenerateCSVProps.property.outputFeatures">outputFeatures</a></code> | <code>string</code> | supports FORMS, TABLES, QUERIES, SIGNATURES as a comma seperated string and generates CSV files for the output from those default is "FORMS,TABLES,QUERIES,SIGNATURES". |
 | <code><a href="#amazon-textract-idp-cdk-constructs.TextractGenerateCSVProps.property.outputPolicyStatements">outputPolicyStatements</a></code> | <code>object</code> | List of PolicyStatements to attach to the Lambda function. |
 | <code><a href="#amazon-textract-idp-cdk-constructs.TextractGenerateCSVProps.property.outputType">outputType</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#amazon-textract-idp-cdk-constructs.TextractGenerateCSVProps.property.s3InputBucket">s3InputBucket</a></code> | <code>string</code> | Bucketname and prefix to read document from /** location of input S3 objects - if left empty will generate rule for s3 access to all [*]. |
@@ -7278,6 +7279,18 @@ public readonly name: string;
 The name of the execution, same as that of StartExecution.
 
 > [https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html)
+
+---
+
+##### `outputFeatures`<sup>Optional</sup> <a name="outputFeatures" id="amazon-textract-idp-cdk-constructs.TextractGenerateCSVProps.property.outputFeatures"></a>
+
+```typescript
+public readonly outputFeatures: string;
+```
+
+- *Type:* string
+
+supports FORMS, TABLES, QUERIES, SIGNATURES as a comma seperated string and generates CSV files for the output from those default is "FORMS,TABLES,QUERIES,SIGNATURES".
 
 ---
 

--- a/lambda/generatecsv/Dockerfile
+++ b/lambda/generatecsv/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/lambda/python:3.9-x86_64
 RUN /var/lang/bin/python -m pip install --upgrade pip
-RUN python -m pip install amazon-textract-idp-cdk-manifest marshmallow amazon-textract-response-parser amazon-textract-prettyprinter>=0.1.0 --target "${LAMBDA_TASK_ROOT}"
+RUN python -m pip install amazon-textract-idp-cdk-manifest marshmallow amazon-textract-response-parser==0.1.44 amazon-textract-prettyprinter==0.1.2 --target "${LAMBDA_TASK_ROOT}"
 
 # Copy function code
 COPY app/* ${LAMBDA_TASK_ROOT}/

--- a/lambda/generatecsv/env.json
+++ b/lambda/generatecsv/env.json
@@ -1,8 +1,10 @@
 {
     "Function": {
-        "CSV_S3_OUTPUT_BUCKET": "idp-stack-python-sample-schademcdkidpstackpython-gnw5reia5742",
+        "CSV_S3_OUTPUT_BUCKET": "generatecsvworkflow-textractsimpleasyncworkflow2d-5za69kjbyg6r",
         "CSV_S3_OUTPUT_PREFIX": "textract-csv-output",
         "LOG_LEVEL": "DEBUG",
-        "OUTPUT_TYPE": "CSV"
+        "OUTPUT_TYPE": "CSV",
+        "OUTPUT_FEATURES": "TABLES,FORMS,SIGNATURES",
+        "TEXTRACT_API": "GENERIC"
     }
 }

--- a/lambda/generatecsv/events/generate_csv_tables.json
+++ b/lambda/generatecsv/events/generate_csv_tables.json
@@ -1,0 +1,16 @@
+{
+    "Token": "AQCYAAAAKgAAAAMAAAAAAAAAAXYRfnURt30xLbFyrPzvSu0F/MzTZPaB7OcE0oG9ZJbfkG5qJhCmLpoVVPvMae2np7t0hSAO16ApqotmGSQWITWblmpb71IlMaqrBtxnVVG/eSpsgtYlIkHIhGo5+nFaIQ==R8NjOTyDECmXkx62V/mR1DTl4i7weSfiqzZMauiwaOIPRuf19+ljL0cBdUlG/tx8IaFWpqBqt5lix2O8ff+8Ia6vuVdM413DGlrszM//+KaUZl3+rfeAQix5ttHOZTR99v/rq1HNxmnRwWZsM+JRqL5s8LNGiRvPZsOpNPlvSoLCTOlDRd3WOmq9FQf55WLb53Mjv4RC2R68kv6bZtq+1lf0sWFZGrDUN07HMAJYpNGVCPfM4OmrB9D0da57DN25HMLqNeV9fYOumddQaEQcFU6bw1RpnE+tQyYbfm4kGGOXrPPM6bZFk6hp/nkEyrBgecnKOAHUC6RrYHBcVfMh2hGLrdLzOGHFECuAdkG1/FuE+oYKAjnXD7YD2YUVxZisAKE6NvyRUqBWEOeOgwcY0a7V7WjJ2uW9RicFXgs8xNMQfRUBInoZRfhVZ2DGehz12Q/QIqWDRzoUdjnkZvkkEqiZOcyizXVpNxaJ/M+c+Nruu7l9TlD5PYnOW25F/LxcRiOV6AKBKzRaKeJRxI6W",
+    "Payload": {
+        "manifest": {
+            "s3Path": "s3://generatecsvworkflow-textractsimpleasyncworkflow2d-5za69kjbyg6r/uploads/paystub-small.png"
+        },
+        "mime": "image/png",
+        "classification": null,
+        "numberOfPages": 1,
+        "textract_result": {
+            "TextractTempOutputJsonPath": "s3://generatecsvworkflow-textractsimpleasyncworkflow2d-5za69kjbyg6r/textract-temp-output/d7badd34c3dd14350c20be65459f143fcf8398723f4e962aa63f07feb0f07cb2",
+            "TextractOutputJsonPath": "s3://generatecsvworkflow-textractsimpleasyncworkflow2d-5za69kjbyg6r/textract-output/paystub-small2023-03-22T23:35:20.108256/paystub-small.json"
+        }
+    },
+    "ExecutionId": "arn:aws:states:us-east-1:913165245630:execution:GenerateCSVWorkflowF9F71ED0-uV6wzLRfulLT:paystub-smallpng2023-03-22T233507050420"
+}

--- a/lambda/generatecsv/template.yaml
+++ b/lambda/generatecsv/template.yaml
@@ -18,11 +18,12 @@ Resources:
         - x86_64
       Environment:
         Variables:
-          CSV_S3_OUTPUT_PREFIX: textract-csv-output
-          CSV_S3_OUTPUT_BUCKET: idp-stack-python-sample-schademcdkidpstackpython-gnw5reia5742
+          CSV_S3_OUTPUT_BUCKET: "generatecsvworkflow-textractsimpleasyncworkflow2d-5za69kjbyg6r"
+          CSV_S3_OUTPUT_PREFIX: "textract-csv-output"
           LOG_LEVEL: DEBUG
-          META_DATA_TO_APPEND: DOCUMENT_ID,SOME_KEY
-          TEXTRACT_API: LENDING
+          META_DATA_TO_APPEND: ""
+          TEXTRACT_API: GENERIC
+          OUTPUT_FEATURES: "TABLES,FORMS,SIGNATURES"
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: .

--- a/src/textractGenerateCSV.ts
+++ b/src/textractGenerateCSV.ts
@@ -58,6 +58,11 @@ export interface TextractGenerateCSVProps extends sfn.TaskStateBaseProps{
   readonly s3InputBucket?: string;
   /** prefix for input S3 objects - if left empty will generate rule for s3 access to all in bucket */
   readonly s3InputPrefix?: string;
+  /** supports FORMS, TABLES, QUERIES, SIGNATURES as a comma seperated string
+   * and generates CSV files for the output from those
+   * default is "FORMS,TABLES,QUERIES,SIGNATURES"
+  */
+  readonly outputFeatures?:string;
   /**
        * The JSON input for the execution, same as that of StartExecution.
        *
@@ -151,6 +156,7 @@ export class TextractGenerateCSV extends sfn.TaskStateBase {
     var lambdaMemoryMB = props.lambdaMemoryMB === undefined ? 1048 : props.lambdaMemoryMB;
     var textractAPI = props.textractAPI === undefined ? 'GENERIC' : props.textractAPI;
     var outputType= props.outputType === undefined ? 'CSV' : props.outputType;
+    var outputFeatures= props.outputFeatures === undefined ? 'FORMS,QUERIES,SIGNATURES,TABLES' : props.outputFeatures;
     var metaDataToAppend= props.metaDataToAppend === undefined ? '' : props.metaDataToAppend;
     var s3TempOutputPrefix =
       props.csvS3OutputPrefix === undefined ? '' : props.csvS3OutputPrefix;
@@ -167,6 +173,7 @@ export class TextractGenerateCSV extends sfn.TaskStateBase {
         CSV_S3_OUTPUT_PREFIX: props.csvS3OutputPrefix,
         LOG_LEVEL: lambdaLogLevel,
         OUTPUT_TYPE: outputType,
+        OUTPUT_FEATURES: outputFeatures,
         TEXTRACT_API: textractAPI,
         META_DATA_TO_APPEND: metaDataToAppend?.toString(),
       },


### PR DESCRIPTION
Fixes #52

Adding outputFeatures option to constructs to select which information goes to a CSV file. Now supports TABLES export as well.
The tables will be exported in the same folder, but with an indicator for page (p) and for the number of table on that page (n).
FORMS, QUERIES and SIGNATURES information is output into one file.

