### PR TITLE
chore: update cdk version and update deprecated methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -390,7 +390,7 @@ export class TextractGenericAsyncSfnTask extends sfn.TaskStateBase {
     const workflow_chain = sfn.Chain.start(textractAsyncCallTask);
 
     this.stateMachine = new sfn.StateMachine(this, 'StateMachine', {
-      definition: workflow_chain,
+      definitionBody: sfn.DefinitionBody.fromChainable(workflow_chain),
       timeout: Duration.hours(textractStateMachineTimeoutMinutes),
     });
 

--- a/src/textractDecider.ts
+++ b/src/textractDecider.ts
@@ -2,8 +2,8 @@ import * as path from 'path';
 import { Duration } from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import * as tasks from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import { INextable, State, StateMachineFragment, Timeout } from 'aws-cdk-lib/aws-stepfunctions';
 import { Construct } from 'constructs';
 
 export interface TextractDPPOCDeciderProps {
@@ -45,9 +45,9 @@ export interface TextractDPPOCDeciderProps {
 
  *
  */
-export class TextractPOCDecider extends sfn.StateMachineFragment {
-  public readonly startState: sfn.State;
-  public readonly endStates: sfn.INextable[];
+export class TextractPOCDecider extends StateMachineFragment {
+  public readonly startState: State;
+  public readonly endStates: INextable[];
   public readonly deciderFunction: lambda.IFunction;
 
   constructor(parent: Construct, id: string, props: TextractDPPOCDeciderProps) {
@@ -103,7 +103,7 @@ export class TextractPOCDecider extends sfn.StateMachineFragment {
     }
     const deciderLambdaInvoke = new tasks.LambdaInvoke(this, id, {
       lambdaFunction: this.deciderFunction,
-      timeout: Duration.seconds(100),
+      taskTimeout: Timeout.duration(Duration.seconds(100)),
       outputPath: '$.Payload',
     });
 


### PR DESCRIPTION
Fixes #

### Old Deprecated Methods
- https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_stepfunctions.TaskStateBaseProps.html#timeoutspan-classapi-icon-api-icon-deprecated-titlethis-api-element-is-deprecated-its-use-is-not-recommended%EF%B8%8Fspan
- https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_stepfunctions.StateMachine.html#definitionspan-classapi-icon-api-icon-deprecated-titlethis-api-element-is-deprecated-its-use-is-not-recommended%EF%B8%8Fspan