### PR TITLE
update: generatecsv Lambda LAYOUT table markdown format

### DIFF
--- a/lambda/generatecsv/app/main.py
+++ b/lambda/generatecsv/app/main.py
@@ -157,6 +157,7 @@ def lambda_handler(event, _):
                     title_prefix="# ",
                     section_header_prefix="## ",
                     list_element_prefix="*",
+                    table_linearization_format="markdown"
                 )
                 for idx, page in enumerate(document.pages):
                     # write output for each page in the form 1-linearized.txt


### PR DESCRIPTION
LAYOUT linearizer in generatecsv Lambda formats content in markdown, except for tables. Added `table_linearization_format = "markdown"` in `textractor.TextLinearizationConfig`.